### PR TITLE
Fix example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ For example:
 ```
 $ curl -X POST http://kong:8001/apis/{api}/plugins \
     --data "name=kong-header-access-control" \
-    --data "config.type: regular" \
-    --data "config.header: MyHeader" \
-    --data "config.whitelist: FirstAllowedVal,SecondAllowedVal"
+    --data "config.type=regular" \
+    --data "config.header=MyHeader" \
+    --data "config.whitelist=FirstAllowedVal,SecondAllowedVal"
 ```
 
 | Parameter  | Description |


### PR DESCRIPTION
Current example will give this error
```
{
  "config.type: regular": "type: regular is an unknown field",
  "config.whitelist: FirstAllowedVal,SecondAllowedVal": "whitelist: FirstAllowedVal,SecondAllowedVal is an unknown field",
  "config.header: MyHeader": "header: MyHeader is an unknown field"
}
```